### PR TITLE
Fixed messages to offline players

### DIFF
--- a/src/main/java/com/mcmiddleearth/plotbuild/data/PluginData.java
+++ b/src/main/java/com/mcmiddleearth/plotbuild/data/PluginData.java
@@ -156,7 +156,7 @@ public class PluginData {
         for(OfflinePlayer offline: offlineMessages.keySet()) {
             if(offline!=null){
                 Player search = offline.getPlayer();
-                if(search==player) {
+                if(search.getUniqueId().equals(player.getUniqueId())) {
                     return offlineMessages.get(offline);
                 }
             }

--- a/src/main/java/com/mcmiddleearth/plotbuild/utils/MessageUtil.java
+++ b/src/main/java/com/mcmiddleearth/plotbuild/utils/MessageUtil.java
@@ -58,8 +58,9 @@ public class MessageUtil {
     }
     
     public static void sendOfflineMessage(OfflinePlayer offlinePlayer, String message) {
-        Player player = offlinePlayer.getPlayer();
-        if(player != null) {
+        
+        if(offlinePlayer.isOnline()) {  
+            Player player = offlinePlayer.getPlayer();
             sendInfoMessage(player, message);
         }
         else {


### PR DESCRIPTION
now using UUIDs for messages to offline players 
improved check for online status of a player, OfflinePlayer.getPlayer() sometimes returns an object even when the player is offline.
